### PR TITLE
Pr/upstream volumeintegrals poison/tile safety

### DIFF
--- a/VolumeIntegrals_GRMHDX/schedule.ccl
+++ b/VolumeIntegrals_GRMHDX/schedule.ccl
@@ -1,7 +1,7 @@
 # Schedule definitions for thorn VolumeIntegrals_GRMHDX
 # $Header:$
 
-STORAGE: VolIntegrands,VolIntegrals,MovingSphRegionIntegrals,IntegralCounterVar,VolIntegrals_vacuum_time
+STORAGE: IntegralCounterVar,VolIntegrals_vacuum_time
 
 
 ##### FILE OUTPUT STUFF #####
@@ -23,6 +23,7 @@ SCHEDULE VI_GRMHDX_file_output_routine_Startup AT CCTK_POST_RECOVER_VARIABLES
 #############################
 SCHEDULE VI_GRMHDX_InitializeIntegralCounterToZero AT CCTK_INITIAL BEFORE AsterX_InitialGroup
 {
+  STORAGE: VolIntegrals,MovingSphRegionIntegrals,GlobalCoM
   LANG: C
   OPTIONS: GLOBAL
   WRITES: IntegralCounter(everywhere) GlobalCoM(everywhere) CoM1(everywhere) CoM2(everywhere) 
@@ -37,6 +38,7 @@ SCHEDULE VI_GRMHDX_InitializeIntegralCounterToZero AT CCTK_INITIAL BEFORE AsterX
 
 SCHEDULE VI_GRMHDX_InitializeIntegralCounterToZero AT CCTK_POST_RECOVER_VARIABLES
 {
+  STORAGE: VolIntegrals,MovingSphRegionIntegrals,GlobalCoM
   LANG: C
   OPTIONS: GLOBAL
   WRITES: IntegralCounter(everywhere) GlobalCoM(everywhere) CoM1(everywhere) CoM2(everywhere) 
@@ -61,8 +63,9 @@ SCHEDULE GROUP VI_GRMHDX_VolumeIntegralGroup AT poststep BEFORE (EstimateError S
 {
 } "Evaluate all volume integrals"
 
-SCHEDULE VI_GRMHDX_ComputeIntegrand in VI_GRMHDX_VolumeIntegralGroup BEFORE VI_GRMHDX_DoSum
+SCHEDULE VI_GRMHDX_ComputeIntegrand in VI_GRMHDX_VolumeIntegralGroup BEFORE VI_GRMHDX_ApplyRegionMasks
 {
+  STORAGE: VolIntegrands,MovingSphRegionIntegrals,GlobalCoM
   LANG: C
   READS: IntegralCounter(everywhere) GlobalCoM(everywhere) 
   READS: BoxInBox::position_x(everywhere) BoxInBox::position_y(everywhere) BoxInBox::position_z(everywhere)
@@ -77,10 +80,7 @@ SCHEDULE VI_GRMHDX_ComputeIntegrand in VI_GRMHDX_VolumeIntegralGroup BEFORE VI_G
   READS: ADMBaseX::gzz(everywhere)
   READS: AsterX::w_lorentz(everywhere)
   READS: AsterX::b2small(everywhere)
-  WRITES: VolIntegrand1(everywhere) 
-  WRITES: VolIntegrand2(everywhere) 
-  WRITES: VolIntegrand3(everywhere) 
-  WRITES: VolIntegrand4(everywhere)
+  WRITES: VolIntegrands(interior)
   WRITES: volintegral_inside_sphere__center_x(everywhere) 
   WRITES: volintegral_inside_sphere__center_y(everywhere) 
   WRITES: volintegral_inside_sphere__center_z(everywhere)
@@ -89,8 +89,31 @@ SCHEDULE VI_GRMHDX_ComputeIntegrand in VI_GRMHDX_VolumeIntegralGroup BEFORE VI_G
   WRITES: volintegral_outside_sphere__center_z(everywhere)
 } "Compute Integrand"
 
-SCHEDULE VI_GRMHDX_DoSum in VI_GRMHDX_VolumeIntegralGroup AFTER VI_GRMHDX_ComputeIntegrand
+SCHEDULE VI_GRMHDX_ApplyRegionMasks in VI_GRMHDX_VolumeIntegralGroup BEFORE VI_GRMHDX_DoSum
 {
+  STORAGE: VolIntegrands,MovingSphRegionIntegrals
+  LANG: C
+  READS: IntegralCounter(everywhere)
+  READS: BoxInBox::position_x(everywhere) BoxInBox::position_y(everywhere) BoxInBox::position_z(everywhere)
+  READS: VolIntegrands(interior)
+  READS: volintegral_inside_sphere__center_x(everywhere)
+  READS: volintegral_inside_sphere__center_y(everywhere)
+  READS: volintegral_inside_sphere__center_z(everywhere)
+  READS: volintegral_outside_sphere__center_x(everywhere)
+  READS: volintegral_outside_sphere__center_y(everywhere)
+  READS: volintegral_outside_sphere__center_z(everywhere)
+  WRITES: VolIntegrands(interior)
+  WRITES: volintegral_inside_sphere__center_x(everywhere)
+  WRITES: volintegral_inside_sphere__center_y(everywhere)
+  WRITES: volintegral_inside_sphere__center_z(everywhere)
+  WRITES: volintegral_outside_sphere__center_x(everywhere)
+  WRITES: volintegral_outside_sphere__center_y(everywhere)
+  WRITES: volintegral_outside_sphere__center_z(everywhere)
+} "Apply sphere-based region masks to integrands"
+
+SCHEDULE VI_GRMHDX_DoSum in VI_GRMHDX_VolumeIntegralGroup AFTER VI_GRMHDX_ApplyRegionMasks
+{
+  STORAGE: VolIntegrands,VolIntegrals,MovingSphRegionIntegrals,GlobalCoM
   OPTIONS: GLOBAL
   LANG: C
   READS: IntegralCounter(everywhere)
@@ -101,7 +124,7 @@ SCHEDULE VI_GRMHDX_DoSum in VI_GRMHDX_VolumeIntegralGroup AFTER VI_GRMHDX_Comput
   READS: volintegral_outside_sphere__center_y(everywhere)
   READS: volintegral_outside_sphere__center_z(everywhere)
   READS: VolIntegral(everywhere)
-  READS: VolIntegrands(everywhere)
+  READS: VolIntegrands(interior)
   READS: BoxInBox::position_x(everywhere)
   READS: BoxInBox::position_y(everywhere)
   READS: BoxInBox::position_z(everywhere)
@@ -126,6 +149,7 @@ SCHEDULE VI_GRMHDX_DecrementIntegralCounter in VI_GRMHDX_VolumeIntegralGroup AFT
 if(enable_file_output) {
   SCHEDULE VI_GRMHDX_file_output after VI_GRMHDX_VolumeIntegralGroup AT CCTK_ANALYSIS
   {
+    STORAGE: VolIntegrals,MovingSphRegionIntegrals,VolIntegrals_vacuum_time
     LANG: C
     OPTIONS: GLOBAL
     READS: volintegral_inside_sphere__center_x(everywhere)

--- a/VolumeIntegrals_GRMHDX/src/evaluate_integrands_local.cxx
+++ b/VolumeIntegrals_GRMHDX/src/evaluate_integrands_local.cxx
@@ -35,7 +35,7 @@ extern "C" void VI_GRMHDX_ComputeIntegrand(CCTK_ARGUMENTS) {
   /* Note: Must extend this if/else statement if adding a new integrand! */
   if (CCTK_EQUALS(Integration_quantity_keyword[which_integral],
                   "centerofmass")) {
-    grid.loop_all_device<1, 1, 1>(
+    grid.loop_int_device<1, 1, 1>(
         grid.nghostzones,
         [=] CCTK_DEVICE(const PointDesc &p) CCTK_ATTRIBUTE_ALWAYS_INLINE {
           CoM_integrand(VolIntegrand1, VolIntegrand2, VolIntegrand3,
@@ -44,39 +44,46 @@ extern "C" void VI_GRMHDX_ComputeIntegrand(CCTK_ARGUMENTS) {
         });
   } else if (CCTK_EQUALS(Integration_quantity_keyword[which_integral],
                          "coordvolume")) {
-    grid.loop_all_device<1, 1, 1>(
+    grid.loop_int_device<1, 1, 1>(
         grid.nghostzones,
         [=] CCTK_DEVICE(const PointDesc &p) CCTK_ATTRIBUTE_ALWAYS_INLINE {
-          CoordVol_integrand(VolIntegrand1, p, rho, dens_atmo);
+          CoordVol_integrand(VolIntegrand1, p, rho, dens_atmo, VolIntegrand2,
+                             VolIntegrand3, VolIntegrand4);
         });
   } else if (CCTK_EQUALS(Integration_quantity_keyword[which_integral],
                          "restmass")) {
-    grid.loop_all_device<1, 1, 1>(
+    grid.loop_int_device<1, 1, 1>(
         grid.nghostzones,
         [=] CCTK_DEVICE(const PointDesc &p) CCTK_ATTRIBUTE_ALWAYS_INLINE {
           M0_integrand(VolIntegrand1, p, w_lorentz, rho, gxx, gxy, gxz, gyy,
-                       gyz, gzz, gamma_lim);
+                       gyz, gzz, gamma_lim, VolIntegrand2, VolIntegrand3,
+                       VolIntegrand4);
         });
   } else if (CCTK_EQUALS(Integration_quantity_keyword[which_integral],
                          "usepreviousintegrands")) {
     /* Do Nothing; the action for this is below. */
   } else if (CCTK_EQUALS(Integration_quantity_keyword[which_integral], "one")) {
-    grid.loop_all_device<1, 1, 1>(
+    grid.loop_int_device<1, 1, 1>(
         grid.nghostzones,
-        [=] CCTK_DEVICE(const PointDesc &p)
-            CCTK_ATTRIBUTE_ALWAYS_INLINE { VolIntegrand1(p.I) = 1.0; });
+        [=] CCTK_DEVICE(const PointDesc &p) CCTK_ATTRIBUTE_ALWAYS_INLINE {
+          VolIntegrand1(p.I) = 1.0;
+          VolIntegrand2(p.I) = 0.0;
+          VolIntegrand3(p.I) = 0.0;
+          VolIntegrand4(p.I) = 0.0;
+        });
   } else if (CCTK_EQUALS(Integration_quantity_keyword[which_integral],
                          "density_weighted_norm_B_field")) {
-    grid.loop_all_device<1, 1, 1>(
+    grid.loop_int_device<1, 1, 1>(
         grid.nghostzones,
         [=] CCTK_DEVICE(const PointDesc &p) CCTK_ATTRIBUTE_ALWAYS_INLINE {
           mean_density_weighted_B(VolIntegrand1, VolIntegrand2, p, w_lorentz,
                                   rho, Bvecx, Bvecy, Bvecz, gxx, gxy, gxz, gyy,
-                                  gyz, gzz, gamma_lim);
+                                  gyz, gzz, gamma_lim, VolIntegrand3,
+                                  VolIntegrand4);
         });
   } else if (CCTK_EQUALS(Integration_quantity_keyword[which_integral],
                          "kinetic_energy")) {
-    grid.loop_all_device<1, 1, 1>(
+    grid.loop_int_device<1, 1, 1>(
         grid.nghostzones,
         [=] CCTK_DEVICE(const PointDesc &p) CCTK_ATTRIBUTE_ALWAYS_INLINE {
           // TODO: Get BNS COM from --BNSTrackerGen-- somewhere
@@ -92,11 +99,11 @@ extern "C" void VI_GRMHDX_ComputeIntegrand(CCTK_ARGUMENTS) {
 
           kinetic(VolIntegrand1, VolIntegrand2, VolIntegrand3, p, velx, vely,
                   velz, w_lorentz, rho, eps, press, gxx, gxy, gxz, gyy, gyz,
-                  gzz, cms_x, cms_y, gamma_lim);
+                  gzz, cms_x, cms_y, gamma_lim, VolIntegrand4);
         });
   } else if (CCTK_EQUALS(Integration_quantity_keyword[which_integral],
                          "kinetic_energy_palenzuela")) {
-    grid.loop_all_device<1, 1, 1>(
+    grid.loop_int_device<1, 1, 1>(
         grid.nghostzones,
         [=] CCTK_DEVICE(const PointDesc &p) CCTK_ATTRIBUTE_ALWAYS_INLINE {
           // TODO: Get BNS COM from --BNSTrackerGen-- somewhere
@@ -113,11 +120,11 @@ extern "C" void VI_GRMHDX_ComputeIntegrand(CCTK_ARGUMENTS) {
           kinetic_palenzuela(VolIntegrand1, VolIntegrand2, VolIntegrand3, p,
                              velx, vely, velz, w_lorentz, rho, eps, press, alp,
                              betax, betay, betaz, gxx, gxy, gxz, gyy, gyz, gzz,
-                             cms_x, cms_y, gamma_lim);
+                             cms_x, cms_y, gamma_lim, VolIntegrand4);
         });
   } else if (CCTK_EQUALS(Integration_quantity_keyword[which_integral],
                          "kinetic_energy_shibata")) {
-    grid.loop_all_device<1, 1, 1>(
+    grid.loop_int_device<1, 1, 1>(
         grid.nghostzones,
         [=] CCTK_DEVICE(const PointDesc &p) CCTK_ATTRIBUTE_ALWAYS_INLINE {
           // TODO: Get BNS COM from --BNSTrackerGen-- somewhere
@@ -134,28 +141,29 @@ extern "C" void VI_GRMHDX_ComputeIntegrand(CCTK_ARGUMENTS) {
           kinetic_shibata(VolIntegrand1, VolIntegrand2, VolIntegrand3, p, velx,
                           vely, velz, w_lorentz, rho, eps, press, alp, betax,
                           betay, betaz, gxx, gxy, gxz, gyy, gyz, gzz, cms_x,
-                          cms_y, gamma_lim);
+                          cms_y, gamma_lim, VolIntegrand4);
         });
   } else if (CCTK_EQUALS(Integration_quantity_keyword[which_integral],
                          "kinetic_energy_total")) {
-    grid.loop_all_device<1, 1, 1>(
+    grid.loop_int_device<1, 1, 1>(
         grid.nghostzones,
         [=] CCTK_DEVICE(const PointDesc &p) CCTK_ATTRIBUTE_ALWAYS_INLINE {
           kinetic_tot(VolIntegrand1, p, velx, vely, velz, w_lorentz, rho, eps,
-                      press, gxx, gxy, gxz, gyy, gyz, gzz, gamma_lim);
+                      press, gxx, gxy, gxz, gyy, gyz, gzz, gamma_lim,
+                      VolIntegrand2, VolIntegrand3, VolIntegrand4);
         });
   } else if (CCTK_EQUALS(Integration_quantity_keyword[which_integral],
                          "thermal_energy")) {
-    grid.loop_all_device<1, 1, 1>(
+    grid.loop_int_device<1, 1, 1>(
         grid.nghostzones,
         [=] CCTK_DEVICE(const PointDesc &p) CCTK_ATTRIBUTE_ALWAYS_INLINE {
           thermal(VolIntegrand1, VolIntegrand2, VolIntegrand3, p, w_lorentz,
                   rho, eps, entropy, gxx, gxy, gxz, gyy, gyz, gzz,
-                  my_baryon_mass, gamma_lim);
+                  my_baryon_mass, gamma_lim, VolIntegrand4);
         });
   } else if (CCTK_EQUALS(Integration_quantity_keyword[which_integral],
                          "magnetic_energy_total")) {
-    grid.loop_all_device<1, 1, 1>(
+    grid.loop_int_device<1, 1, 1>(
         grid.nghostzones,
         [=] CCTK_DEVICE(const PointDesc &p) CCTK_ATTRIBUTE_ALWAYS_INLINE {
           // TODO: Get BNS COM from --BNSTrackerGen-- somewhere
@@ -171,11 +179,11 @@ extern "C" void VI_GRMHDX_ComputeIntegrand(CCTK_ARGUMENTS) {
 
           magnetic_tot(VolIntegrand1, VolIntegrand2, p, velx, vely, velz, Bvecx,
                        Bvecy, Bvecz, gxx, gxy, gxz, gyy, gyz, gzz, cms_x,
-                       cms_y);
+                       cms_y, VolIntegrand3, VolIntegrand4);
         });
   } else if (CCTK_EQUALS(Integration_quantity_keyword[which_integral],
                          "em_energy_ab")) {
-    grid.loop_all_device<1, 1, 1>(
+    grid.loop_int_device<1, 1, 1>(
         grid.nghostzones,
         [=] CCTK_DEVICE(const PointDesc &p) CCTK_ATTRIBUTE_ALWAYS_INLINE {
           // TODO: Get BNS COM from --BNSTrackerGen-- somewhere
@@ -191,11 +199,12 @@ extern "C" void VI_GRMHDX_ComputeIntegrand(CCTK_ARGUMENTS) {
 
           magnetic_tot_12(VolIntegrand1, VolIntegrand2, p, rho, dens_a, dens_b,
                           velx, vely, velz, Bvecx, Bvecy, Bvecz, gxx, gxy, gxz,
-                          gyy, gyz, gzz, cms_x, cms_y);
+                          gyy, gyz, gzz, cms_x, cms_y, VolIntegrand3,
+                          VolIntegrand4);
         });
   } else if (CCTK_EQUALS(Integration_quantity_keyword[which_integral],
                          "em_energy_cd")) {
-    grid.loop_all_device<1, 1, 1>(
+    grid.loop_int_device<1, 1, 1>(
         grid.nghostzones,
         [=] CCTK_DEVICE(const PointDesc &p) CCTK_ATTRIBUTE_ALWAYS_INLINE {
           // TODO: Get BNS COM from --BNSTrackerGen-- somewhere
@@ -211,11 +220,12 @@ extern "C" void VI_GRMHDX_ComputeIntegrand(CCTK_ARGUMENTS) {
 
           magnetic_tot_12(VolIntegrand1, VolIntegrand2, p, rho, dens_c, dens_d,
                           velx, vely, velz, Bvecx, Bvecy, Bvecz, gxx, gxy, gxz,
-                          gyy, gyz, gzz, cms_x, cms_y);
+                          gyy, gyz, gzz, cms_x, cms_y, VolIntegrand3,
+                          VolIntegrand4);
         });
   } else if (CCTK_EQUALS(Integration_quantity_keyword[which_integral],
                          "em_energy_posz")) {
-    grid.loop_all_device<1, 1, 1>(
+    grid.loop_int_device<1, 1, 1>(
         grid.nghostzones,
         [=] CCTK_DEVICE(const PointDesc &p) CCTK_ATTRIBUTE_ALWAYS_INLINE {
           // TODO: Get BNS COM from --BNSTrackerGen-- somewhere
@@ -231,13 +241,14 @@ extern "C" void VI_GRMHDX_ComputeIntegrand(CCTK_ARGUMENTS) {
             cms_z = *comz;
           }
 
-          magnetic_tot_zsplit(VolIntegrand1, VolIntegrand2, p,
-                          velx, vely, velz, Bvecx, Bvecy, Bvecz, gxx, gxy, gxz,
-                          gyy, gyz, gzz, cms_x, cms_y, cms_z, 1);
+          magnetic_tot_zsplit(VolIntegrand1, VolIntegrand2, VolIntegrand3,
+                              VolIntegrand4, p, velx, vely, velz, Bvecx, Bvecy,
+                              Bvecz, gxx, gxy, gxz, gyy, gyz, gzz, cms_x,
+                              cms_y, cms_z, 1);
         });
   } else if (CCTK_EQUALS(Integration_quantity_keyword[which_integral],
                          "em_energy_negz")) {
-    grid.loop_all_device<1, 1, 1>(
+    grid.loop_int_device<1, 1, 1>(
         grid.nghostzones,
         [=] CCTK_DEVICE(const PointDesc &p) CCTK_ATTRIBUTE_ALWAYS_INLINE {
           // TODO: Get BNS COM from --BNSTrackerGen-- somewhere
@@ -253,13 +264,14 @@ extern "C" void VI_GRMHDX_ComputeIntegrand(CCTK_ARGUMENTS) {
             cms_z = *comz;
           }
 
-          magnetic_tot_zsplit(VolIntegrand1, VolIntegrand2, p, 
-                          velx, vely, velz, Bvecx, Bvecy, Bvecz, gxx, gxy, gxz,
-                          gyy, gyz, gzz, cms_x, cms_y, cms_z, -1);
+          magnetic_tot_zsplit(VolIntegrand1, VolIntegrand2, VolIntegrand3,
+                              VolIntegrand4, p, velx, vely, velz, Bvecx, Bvecy,
+                              Bvecz, gxx, gxy, gxz, gyy, gyz, gzz, cms_x,
+                              cms_y, cms_z, -1);
         });
   } else if (CCTK_EQUALS(Integration_quantity_keyword[which_integral],
                          "volume_average_norm_B_ab")) {
-    grid.loop_all_device<1, 1, 1>(
+    grid.loop_int_device<1, 1, 1>(
         grid.nghostzones,
         [=] CCTK_DEVICE(const PointDesc &p) CCTK_ATTRIBUTE_ALWAYS_INLINE {
           // TODO: Get BNS COM from --BNSTrackerGen-- somewhere
@@ -279,7 +291,7 @@ extern "C" void VI_GRMHDX_ComputeIntegrand(CCTK_ARGUMENTS) {
         });
   } else if (CCTK_EQUALS(Integration_quantity_keyword[which_integral],
                          "volume_average_norm_B_cd")) {
-    grid.loop_all_device<1, 1, 1>(
+    grid.loop_int_device<1, 1, 1>(
         grid.nghostzones,
         [=] CCTK_DEVICE(const PointDesc &p) CCTK_ATTRIBUTE_ALWAYS_INLINE {
           // TODO: Get BNS COM from --BNSTrackerGen-- somewhere
@@ -299,7 +311,7 @@ extern "C" void VI_GRMHDX_ComputeIntegrand(CCTK_ARGUMENTS) {
         });
   } else if (CCTK_EQUALS(Integration_quantity_keyword[which_integral],
                          "volume_average_norm_B_posz")) {
-    grid.loop_all_device<1, 1, 1>(
+    grid.loop_int_device<1, 1, 1>(
         grid.nghostzones,
         [=] CCTK_DEVICE(const PointDesc &p) CCTK_ATTRIBUTE_ALWAYS_INLINE {
           // TODO: Get BNS COM from --BNSTrackerGen-- somewhere
@@ -316,12 +328,12 @@ extern "C" void VI_GRMHDX_ComputeIntegrand(CCTK_ARGUMENTS) {
           }
 
           volume_norm_B_zsplit(VolIntegrand1, VolIntegrand2, VolIntegrand3,
-                           VolIntegrand4, p, Bvecx, Bvecy,
-                           Bvecz, gxx, gxy, gxz, gyy, gyz, gzz, cms_x, cms_y, cms_z, 1);
+                               VolIntegrand4, p, Bvecx, Bvecy, Bvecz, gxx, gxy,
+                               gxz, gyy, gyz, gzz, cms_x, cms_y, cms_z, 1);
         });
   } else if (CCTK_EQUALS(Integration_quantity_keyword[which_integral],
                          "volume_average_norm_B_negz")) {
-    grid.loop_all_device<1, 1, 1>(
+    grid.loop_int_device<1, 1, 1>(
         grid.nghostzones,
         [=] CCTK_DEVICE(const PointDesc &p) CCTK_ATTRIBUTE_ALWAYS_INLINE {
           // TODO: Get BNS COM from --BNSTrackerGen-- somewhere
@@ -338,12 +350,12 @@ extern "C" void VI_GRMHDX_ComputeIntegrand(CCTK_ARGUMENTS) {
           }
 
           volume_norm_B_zsplit(VolIntegrand1, VolIntegrand2, VolIntegrand3,
-                           VolIntegrand4, p, Bvecx, Bvecy,
-                           Bvecz, gxx, gxy, gxz, gyy, gyz, gzz, cms_x, cms_y, cms_z, -1);
+                               VolIntegrand4, p, Bvecx, Bvecy, Bvecz, gxx, gxy,
+                               gxz, gyy, gyz, gzz, cms_x, cms_y, cms_z, -1);
         });
   } else if (CCTK_EQUALS(Integration_quantity_keyword[which_integral],
                          "volume_average_norm_B_m1_cd")) {
-    grid.loop_all_device<1, 1, 1>(
+    grid.loop_int_device<1, 1, 1>(
         grid.nghostzones,
         [=] CCTK_DEVICE(const PointDesc &p) CCTK_ATTRIBUTE_ALWAYS_INLINE {
           // TODO: Get BNS COM from --BNSTrackerGen-- somewhere
@@ -358,12 +370,13 @@ extern "C" void VI_GRMHDX_ComputeIntegrand(CCTK_ARGUMENTS) {
           }
 
           volume_norm_B_m_12(VolIntegrand1, VolIntegrand2, VolIntegrand3,
-                           VolIntegrand4, p, rho, dens_c, dens_d, Bvecx, Bvecy,
-                           Bvecz, gxx, gxy, gxz, gyy, gyz, gzz, cms_x, cms_y, 1);
+                             VolIntegrand4, p, rho, dens_c, dens_d, Bvecx,
+                             Bvecy, Bvecz, gxx, gxy, gxz, gyy, gyz, gzz, cms_x,
+                             cms_y, 1);
         });
   } else if (CCTK_EQUALS(Integration_quantity_keyword[which_integral],
                          "volume_average_norm_B_m2_cd")) {
-    grid.loop_all_device<1, 1, 1>(
+    grid.loop_int_device<1, 1, 1>(
         grid.nghostzones,
         [=] CCTK_DEVICE(const PointDesc &p) CCTK_ATTRIBUTE_ALWAYS_INLINE {
           // TODO: Get BNS COM from --BNSTrackerGen-- somewhere
@@ -378,12 +391,13 @@ extern "C" void VI_GRMHDX_ComputeIntegrand(CCTK_ARGUMENTS) {
           }
 
           volume_norm_B_m_12(VolIntegrand1, VolIntegrand2, VolIntegrand3,
-                           VolIntegrand4, p, rho, dens_c, dens_d, Bvecx, Bvecy,
-                           Bvecz, gxx, gxy, gxz, gyy, gyz, gzz, cms_x, cms_y, 2);
+                             VolIntegrand4, p, rho, dens_c, dens_d, Bvecx,
+                             Bvecy, Bvecz, gxx, gxy, gxz, gyy, gyz, gzz, cms_x,
+                             cms_y, 2);
         });
   } else if (CCTK_EQUALS(Integration_quantity_keyword[which_integral],
                          "volume_average_norm_B_m3_cd")) {
-    grid.loop_all_device<1, 1, 1>(
+    grid.loop_int_device<1, 1, 1>(
         grid.nghostzones,
         [=] CCTK_DEVICE(const PointDesc &p) CCTK_ATTRIBUTE_ALWAYS_INLINE {
           // TODO: Get BNS COM from --BNSTrackerGen-- somewhere
@@ -398,12 +412,13 @@ extern "C" void VI_GRMHDX_ComputeIntegrand(CCTK_ARGUMENTS) {
           }
 
           volume_norm_B_m_12(VolIntegrand1, VolIntegrand2, VolIntegrand3,
-                           VolIntegrand4, p, rho, dens_c, dens_d, Bvecx, Bvecy,
-                           Bvecz, gxx, gxy, gxz, gyy, gyz, gzz, cms_x, cms_y, 3);
+                             VolIntegrand4, p, rho, dens_c, dens_d, Bvecx,
+                             Bvecy, Bvecz, gxx, gxy, gxz, gyy, gyz, gzz, cms_x,
+                             cms_y, 3);
         });
   } else if (CCTK_EQUALS(Integration_quantity_keyword[which_integral],
                          "volume_average_norm_B_m4_cd")) {
-    grid.loop_all_device<1, 1, 1>(
+    grid.loop_int_device<1, 1, 1>(
         grid.nghostzones,
         [=] CCTK_DEVICE(const PointDesc &p) CCTK_ATTRIBUTE_ALWAYS_INLINE {
           // TODO: Get BNS COM from --BNSTrackerGen-- somewhere
@@ -418,16 +433,18 @@ extern "C" void VI_GRMHDX_ComputeIntegrand(CCTK_ARGUMENTS) {
           }
 
           volume_norm_B_m_12(VolIntegrand1, VolIntegrand2, VolIntegrand3,
-                           VolIntegrand4, p, rho, dens_c, dens_d, Bvecx, Bvecy,
-                           Bvecz, gxx, gxy, gxz, gyy, gyz, gzz, cms_x, cms_y, 4);
+                             VolIntegrand4, p, rho, dens_c, dens_d, Bvecx,
+                             Bvecy, Bvecz, gxx, gxy, gxz, gyy, gyz, gzz, cms_x,
+                             cms_y, 4);
         });
   } else if (CCTK_EQUALS(Integration_quantity_keyword[which_integral],
                          "magnetic_energy_comov")) {
-    grid.loop_all_device<1, 1, 1>(
+    grid.loop_int_device<1, 1, 1>(
         grid.nghostzones,
         [=] CCTK_DEVICE(const PointDesc &p) CCTK_ATTRIBUTE_ALWAYS_INLINE {
           magnetic_co(VolIntegrand1, p, b2small, w_lorentz, gxx, gxy, gxz, gyy,
-                      gyz, gzz, gamma_lim);
+                      gyz, gzz, gamma_lim, VolIntegrand2, VolIntegrand3,
+                      VolIntegrand4);
         });
   } else {
     /* Print a warning if no integrand is computed because
@@ -435,6 +452,17 @@ extern "C" void VI_GRMHDX_ComputeIntegrand(CCTK_ARGUMENTS) {
     printf("VolumeIntegrals: WARNING: Integrand not computed. Did not "
            "understand Integration_quantity_keyword[%d] = %s\n",
            which_integral, Integration_quantity_keyword[which_integral]);
+  }
+}
+
+extern "C" void VI_GRMHDX_ApplyRegionMasks(CCTK_ARGUMENTS) {
+  DECLARE_CCTK_ARGUMENTSX_VI_GRMHDX_ApplyRegionMasks;
+  DECLARE_CCTK_PARAMETERS;
+
+  const int which_integral = NumIntegrals - static_cast<int>(*IntegralCounter) + 1;
+  if (which_integral < 1 || which_integral > NumIntegrals || which_integral > 100) {
+    CCTK_VERROR("Invalid integral index: which_integral=%d NumIntegrals=%d IntegralCounter=%d",
+                which_integral, NumIntegrals, static_cast<int>(*IntegralCounter));
   }
 
   if (cctk_iteration == 0) {
@@ -506,7 +534,7 @@ extern "C" void VI_GRMHDX_ComputeIntegrand(CCTK_ARGUMENTS) {
       yprime = volintegral_inside_sphere__center_y[which_integral];
       zprime = volintegral_inside_sphere__center_z[which_integral];
     }
-    grid.loop_all_device<1, 1, 1>(
+    grid.loop_int_device<1, 1, 1>(
         grid.nghostzones,
         [=] CCTK_DEVICE(const PointDesc &p) CCTK_ATTRIBUTE_ALWAYS_INLINE {
           double x_minus_xprime = p.x - xprime;
@@ -533,7 +561,7 @@ extern "C" void VI_GRMHDX_ComputeIntegrand(CCTK_ARGUMENTS) {
     double xprime = volintegral_outside_sphere__center_x[which_integral];
     double yprime = volintegral_outside_sphere__center_y[which_integral];
     double zprime = volintegral_outside_sphere__center_z[which_integral];
-    grid.loop_all_device<1, 1, 1>(
+    grid.loop_int_device<1, 1, 1>(
         grid.nghostzones,
         [=] CCTK_DEVICE(const PointDesc &p) CCTK_ATTRIBUTE_ALWAYS_INLINE {
           double x_minus_xprime = p.x - xprime;

--- a/VolumeIntegrals_GRMHDX/src/integrands.cxx
+++ b/VolumeIntegrals_GRMHDX/src/integrands.cxx
@@ -139,7 +139,10 @@ CCTK_DEVICE CCTK_HOST CCTK_ATTRIBUTE_ALWAYS_INLINE inline void
 CoordVol_integrand(const Loop::GF3D2<double> VolIntegrand1,
                    const Loop::PointDesc &p,
                    const Loop::GF3D2<const double> rho0,
-                   const CCTK_REAL dens_1) {
+                   const CCTK_REAL dens_1,
+                   const Loop::GF3D2<double> VolIntegrand2,
+                   const Loop::GF3D2<double> VolIntegrand3,
+                   const Loop::GF3D2<double> VolIntegrand4) {
 
   const CCTK_REAL my_rho = rho0(p.I);
   if (my_rho > dens_1) {
@@ -147,6 +150,9 @@ CoordVol_integrand(const Loop::GF3D2<double> VolIntegrand1,
   } else {
     VolIntegrand1(p.I) = 0.0;
   }
+  VolIntegrand2(p.I) = 0.0;
+  VolIntegrand3(p.I) = 0.0;
+  VolIntegrand4(p.I) = 0.0;
 }
 
 /* Center of Mass: */
@@ -175,10 +181,16 @@ CCTK_DEVICE CCTK_HOST CCTK_ATTRIBUTE_ALWAYS_INLINE inline void M0_integrand(
     const Loop::GF3D2<const double> rho0, const Loop::GF3D2<const double> gxx,
     const Loop::GF3D2<const double> gxy, const Loop::GF3D2<const double> gxz,
     const Loop::GF3D2<const double> gyy, const Loop::GF3D2<const double> gyz,
-    const Loop::GF3D2<const double> gzz, const CCTK_REAL gamma_lim) {
+    const Loop::GF3D2<const double> gzz, const CCTK_REAL gamma_lim,
+    const Loop::GF3D2<double> VolIntegrand2,
+    const Loop::GF3D2<double> VolIntegrand3,
+    const Loop::GF3D2<double> VolIntegrand4) {
   double rho_starL = compute_rho_star(p, w_lorentz, rho0, gxx, gxy, gxz, gyy,
                                       gyz, gzz, gamma_lim);
   VolIntegrand1(p.I) = rho_starL;
+  VolIntegrand2(p.I) = 0.0;
+  VolIntegrand3(p.I) = 0.0;
+  VolIntegrand4(p.I) = 0.0;
 }
 
 /* Density weighted norm of magnetic field strength: */
@@ -193,7 +205,9 @@ mean_density_weighted_B(
     const Loop::GF3D2<const double> rho0, const Loop::GF3D2<const double> gxx,
     const Loop::GF3D2<const double> gxy, const Loop::GF3D2<const double> gxz,
     const Loop::GF3D2<const double> gyy, const Loop::GF3D2<const double> gyz,
-    const Loop::GF3D2<const double> gzz, const CCTK_REAL gamma_lim) {
+    const Loop::GF3D2<const double> gzz, const CCTK_REAL gamma_lim,
+    const Loop::GF3D2<double> VolIntegrand3,
+    const Loop::GF3D2<double> VolIntegrand4) {
   const CCTK_REAL gammaDD00 = gxx(p.I);
   const CCTK_REAL gammaDD01 = gxy(p.I);
   const CCTK_REAL gammaDD02 = gxz(p.I);
@@ -213,6 +227,8 @@ mean_density_weighted_B(
                      2. * gammaDD12 * By * Bz + gammaDD22 * Bz * Bz;
   VolIntegrand1(p.I) = rho_starL * sqrt(norm_B_sq);
   VolIntegrand2(p.I) = rho_starL;
+  VolIntegrand3(p.I) = 0.0;
+  VolIntegrand4(p.I) = 0.0;
 }
 
 /* Volume averaged norm of B in region (dens_1,dens_2]: */
@@ -508,7 +524,8 @@ CCTK_DEVICE CCTK_HOST CCTK_ATTRIBUTE_ALWAYS_INLINE inline void kinetic_shibata(
     const Loop::GF3D2<const double> gxx, const Loop::GF3D2<const double> gxy,
     const Loop::GF3D2<const double> gxz, const Loop::GF3D2<const double> gyy,
     const Loop::GF3D2<const double> gyz, const Loop::GF3D2<const double> gzz,
-    const double cms_x, const double cms_y, const double gamma_lim) {
+    const double cms_x, const double cms_y, const double gamma_lim,
+    const Loop::GF3D2<double> VolIntegrand4) {
 
   const CCTK_REAL gammaDD00 = gxx(p.I);
   const CCTK_REAL gammaDD01 = gxy(p.I);
@@ -608,6 +625,7 @@ CCTK_DEVICE CCTK_HOST CCTK_ATTRIBUTE_ALWAYS_INLINE inline void kinetic_shibata(
   VolIntegrand3(p.I) = 0.5 * sqrtgamma * (my_rho * (1.0 + my_eps) + my_press) *
                        w_lorentz_limited * w_lorentz_limited *
                        (my_lapse * vz_2 - shiftz_vz);
+  VolIntegrand4(p.I) = 0.0;
 }
 
 /* Kinetic energy as given by https://arxiv.org/pdf/2112.08413.pdf */
@@ -629,7 +647,8 @@ kinetic_palenzuela(
     const Loop::GF3D2<const double> gxx, const Loop::GF3D2<const double> gxy,
     const Loop::GF3D2<const double> gxz, const Loop::GF3D2<const double> gyy,
     const Loop::GF3D2<const double> gyz, const Loop::GF3D2<const double> gzz,
-    const double cms_x, const double cms_y, const double gamma_lim) {
+    const double cms_x, const double cms_y, const double gamma_lim,
+    const Loop::GF3D2<double> VolIntegrand4) {
 
   const CCTK_REAL gammaDD00 = gxx(p.I);
   const CCTK_REAL gammaDD01 = gxy(p.I);
@@ -729,6 +748,7 @@ kinetic_palenzuela(
   VolIntegrand3(p.I) = 0.5 * sqrtgamma * (my_rho * (1.0 + my_eps) + my_press) *
                        w_lorentz_limited * w_lorentz_limited *
                        (vz_2 - shiftz_vz / my_lapse);
+  VolIntegrand4(p.I) = 0.0;
 }
 
 /* Kinetic energy density given by 0.5*rhoh*W^2v^2 */
@@ -745,7 +765,8 @@ CCTK_DEVICE CCTK_HOST CCTK_ATTRIBUTE_ALWAYS_INLINE inline void kinetic(
     const Loop::GF3D2<const double> gxx, const Loop::GF3D2<const double> gxy,
     const Loop::GF3D2<const double> gxz, const Loop::GF3D2<const double> gyy,
     const Loop::GF3D2<const double> gyz, const Loop::GF3D2<const double> gzz,
-    const double cms_x, const double cms_y, const double gamma_lim) {
+    const double cms_x, const double cms_y, const double gamma_lim,
+    const Loop::GF3D2<double> VolIntegrand4) {
 
   const CCTK_REAL gammaDD00 = gxx(p.I);
   const CCTK_REAL gammaDD01 = gxy(p.I);
@@ -822,6 +843,7 @@ CCTK_DEVICE CCTK_HOST CCTK_ATTRIBUTE_ALWAYS_INLINE inline void kinetic(
 
   VolIntegrand3(p.I) = 0.5 * sqrtgamma * (my_rho * (1.0 + my_eps) + my_press) *
                        (w_lorentz_limited * w_lorentz_limited * vz_2);
+  VolIntegrand4(p.I) = 0.0;
 }
 
 /* Total kinetic energy as defined by total energy in hydro sector - rest mass -
@@ -837,7 +859,9 @@ CCTK_DEVICE CCTK_HOST CCTK_ATTRIBUTE_ALWAYS_INLINE inline void kinetic_tot(
     const Loop::GF3D2<const double> gxx, const Loop::GF3D2<const double> gxy,
     const Loop::GF3D2<const double> gxz, const Loop::GF3D2<const double> gyy,
     const Loop::GF3D2<const double> gyz, const Loop::GF3D2<const double> gzz,
-    const double gamma_lim) {
+    const double gamma_lim, const Loop::GF3D2<double> VolIntegrand2,
+    const Loop::GF3D2<double> VolIntegrand3,
+    const Loop::GF3D2<double> VolIntegrand4) {
 
   const CCTK_REAL gammaDD00 = gxx(p.I);
   const CCTK_REAL gammaDD01 = gxy(p.I);
@@ -885,6 +909,9 @@ CCTK_DEVICE CCTK_HOST CCTK_ATTRIBUTE_ALWAYS_INLINE inline void kinetic_tot(
   VolIntegrand1(p.I) =
       sqrtgamma * (my_press * (w_lorentz_limited * w_lorentz_limited * v_2) +
                    (my_rho * (1.0 + my_eps)) * w_lorentz_limited * wm1);
+  VolIntegrand2(p.I) = 0.0;
+  VolIntegrand3(p.I) = 0.0;
+  VolIntegrand4(p.I) = 0.0;
 }
 
 /* Thermal energy:
@@ -906,7 +933,8 @@ CCTK_DEVICE CCTK_HOST CCTK_ATTRIBUTE_ALWAYS_INLINE inline void thermal(
     const Loop::GF3D2<const double> gxx, const Loop::GF3D2<const double> gxy,
     const Loop::GF3D2<const double> gxz, const Loop::GF3D2<const double> gyy,
     const Loop::GF3D2<const double> gyz, const Loop::GF3D2<const double> gzz,
-    const double my_baryon_mass, const double gamma_lim) {
+    const double my_baryon_mass, const double gamma_lim,
+    const Loop::GF3D2<double> VolIntegrand4) {
 
   const CCTK_REAL w_lorentz = w_lorentzGF(p.I);
   const CCTK_REAL rho0 = rho0GF(p.I);
@@ -929,6 +957,7 @@ CCTK_DEVICE CCTK_HOST CCTK_ATTRIBUTE_ALWAYS_INLINE inline void thermal(
   // Total entropy
   VolIntegrand3(p.I) =
       sqrtgamma * rho0 * entropy * w_lorentz_limited / my_baryon_mass;
+  VolIntegrand4(p.I) = 0.0;
 }
 
 CCTK_DEVICE CCTK_HOST CCTK_ATTRIBUTE_ALWAYS_INLINE inline void magnetic_co(
@@ -938,7 +967,9 @@ CCTK_DEVICE CCTK_HOST CCTK_ATTRIBUTE_ALWAYS_INLINE inline void magnetic_co(
     const Loop::GF3D2<const double> gxx, const Loop::GF3D2<const double> gxy,
     const Loop::GF3D2<const double> gxz, const Loop::GF3D2<const double> gyy,
     const Loop::GF3D2<const double> gyz, const Loop::GF3D2<const double> gzz,
-    const double gamma_lim) {
+    const double gamma_lim, const Loop::GF3D2<double> VolIntegrand2,
+    const Loop::GF3D2<double> VolIntegrand3,
+    const Loop::GF3D2<double> VolIntegrand4) {
 
   const CCTK_REAL b2small = b2smallGF(p.I);
   const CCTK_REAL w_lorentz = w_lorentzGF(p.I);
@@ -951,6 +982,9 @@ CCTK_DEVICE CCTK_HOST CCTK_ATTRIBUTE_ALWAYS_INLINE inline void magnetic_co(
   double sqrtgamma = compute_sqrtgamma(p, gxx, gxy, gxz, gyy, gyz, gzz);
 
   VolIntegrand1(p.I) = sqrtgamma * w_lorentz_limited * b2small / 2.0;
+  VolIntegrand2(p.I) = 0.0;
+  VolIntegrand3(p.I) = 0.0;
+  VolIntegrand4(p.I) = 0.0;
 }
 
 /* Magnetic energy split into azimuthal energy component and rest: */
@@ -964,7 +998,8 @@ CCTK_DEVICE CCTK_HOST CCTK_ATTRIBUTE_ALWAYS_INLINE inline void magnetic_tot(
     const Loop::GF3D2<const double> gxy, const Loop::GF3D2<const double> gxz,
     const Loop::GF3D2<const double> gyy, const Loop::GF3D2<const double> gyz,
     const Loop::GF3D2<const double> gzz, const double cms_x,
-    const double cms_y) {
+    const double cms_y, const Loop::GF3D2<double> VolIntegrand3,
+    const Loop::GF3D2<double> VolIntegrand4) {
 
   // Notice that CoM_integrand_GAMMA_SPEED_LIMIT is applied to the integrands
   // above involving the Lorentz factor w_lorentz. The be consistent we probably
@@ -1078,12 +1113,16 @@ CCTK_DEVICE CCTK_HOST CCTK_ATTRIBUTE_ALWAYS_INLINE inline void magnetic_tot(
       (E_2 + sqrtgammaE_cov[2] * sqrtgammaE_contra[2] / sqrtgamma + B_2 +
        B_cov[2] * B_contra[2] * sqrtgamma) /
       2.0;
+  VolIntegrand3(p.I) = 0.0;
+  VolIntegrand4(p.I) = 0.0;
 }
 
 /* Magnetic energy in +/- z domain: */
 CCTK_DEVICE CCTK_HOST CCTK_ATTRIBUTE_ALWAYS_INLINE inline void magnetic_tot_zsplit(
     const Loop::GF3D2<double> VolIntegrand1,
-    const Loop::GF3D2<double> VolIntegrand2, const Loop::PointDesc &p,
+    const Loop::GF3D2<double> VolIntegrand2,
+    const Loop::GF3D2<double> VolIntegrand3,
+    const Loop::GF3D2<double> VolIntegrand4, const Loop::PointDesc &p,
     const Loop::GF3D2<const double> velx, const Loop::GF3D2<const double> vely,
     const Loop::GF3D2<const double> velz, const Loop::GF3D2<const double> Bvecx,
     const Loop::GF3D2<const double> Bvecy,
@@ -1206,10 +1245,14 @@ CCTK_DEVICE CCTK_HOST CCTK_ATTRIBUTE_ALWAYS_INLINE inline void magnetic_tot_zspl
         (E_2 + sqrtgammaE_cov[2] * sqrtgammaE_contra[2] / sqrtgamma + B_2 +
          B_cov[2] * B_contra[2] * sqrtgamma) /
         2.0;
+    VolIntegrand3(p.I) = 0.0;
+    VolIntegrand4(p.I) = 0.0;
   } else {
 
     VolIntegrand1(p.I) = 0.0;
     VolIntegrand2(p.I) = 0.0;
+    VolIntegrand3(p.I) = 0.0;
+    VolIntegrand4(p.I) = 0.0;
   }
 }
 
@@ -1227,7 +1270,8 @@ CCTK_DEVICE CCTK_HOST CCTK_ATTRIBUTE_ALWAYS_INLINE inline void magnetic_tot_12(
     const Loop::GF3D2<const double> gxy, const Loop::GF3D2<const double> gxz,
     const Loop::GF3D2<const double> gyy, const Loop::GF3D2<const double> gyz,
     const Loop::GF3D2<const double> gzz, const double cms_x,
-    const double cms_y) {
+    const double cms_y, const Loop::GF3D2<double> VolIntegrand3,
+    const Loop::GF3D2<double> VolIntegrand4) {
 
   // Notice that CoM_integrand_GAMMA_SPEED_LIMIT is applied to the integrands
   // above involving the Lorentz factor w_lorentz. The be consistent we probably
@@ -1345,11 +1389,15 @@ CCTK_DEVICE CCTK_HOST CCTK_ATTRIBUTE_ALWAYS_INLINE inline void magnetic_tot_12(
         (E_2 + sqrtgammaE_cov[2] * sqrtgammaE_contra[2] / sqrtgamma + B_2 +
          B_cov[2] * B_contra[2] * sqrtgamma) /
         2.0;
+    VolIntegrand3(p.I) = 0.0;
+    VolIntegrand4(p.I) = 0.0;
 
   } else {
 
     VolIntegrand1(p.I) = 0.0;
     VolIntegrand2(p.I) = 0.0;
+    VolIntegrand3(p.I) = 0.0;
+    VolIntegrand4(p.I) = 0.0;
   }
 }
 #endif

--- a/VolumeIntegrals_vacuumX/schedule.ccl
+++ b/VolumeIntegrals_vacuumX/schedule.ccl
@@ -1,7 +1,7 @@
 # Schedule definitions for thorn VolumeIntegrals_vacuumX
 # $Header:$
 
-STORAGE: VolIntegrands,VolIntegrals,MovingSphRegionIntegrals,IntegralCounterVar,VolIntegrals_vacuum_time
+STORAGE: IntegralCounterVar,VolIntegrals_vacuum_time
 
 
 ##### FILE OUTPUT STUFF #####
@@ -23,6 +23,7 @@ SCHEDULE VI_vacuumX_file_output_routine_Startup AT CCTK_POST_RECOVER_VARIABLES
 #############################
 SCHEDULE VI_vacuumX_InitializeIntegralCounterToZero AT CCTK_INITIAL
 {
+  STORAGE: VolIntegrals,MovingSphRegionIntegrals
   LANG: C
   OPTIONS: GLOBAL
   WRITES: IntegralCounter(everywhere)
@@ -38,6 +39,7 @@ SCHEDULE VI_vacuumX_InitializeIntegralCounterToZero AT CCTK_INITIAL
 
 SCHEDULE VI_vacuumX_InitializeIntegralCounterToZero AT CCTK_POST_RECOVER_VARIABLES
 {
+  STORAGE: VolIntegrals,MovingSphRegionIntegrals
   LANG: C
   OPTIONS: GLOBAL
   WRITES: IntegralCounter(everywhere)
@@ -64,9 +66,30 @@ SCHEDULE GROUP VI_vacuumX_VolumeIntegralGroup AT CCTK_ANALYSIS WHILE VolumeInteg
 {
 } "Evaluate all volume integrals"
 
-SCHEDULE VI_vacuumX_ComputeIntegrand in VI_vacuumX_VolumeIntegralGroup BEFORE VI_vacuumX_DoSum
+SCHEDULE VI_vacuumX_ComputeIntegrandFluxes in VI_vacuumX_VolumeIntegralGroup BEFORE VI_vacuumX_ComputeIntegrand
 {
-  STORAGE: VolIntegrands,VolIntegrals,MovingSphRegionIntegrals
+  STORAGE: VolIntegrands
+  LANG: C
+  READS: IntegralCounter(everywhere)
+  READS: ADMBaseX::alp(everywhere)
+  READS: ADMBaseX::gxx(everywhere)
+  READS: ADMBaseX::gxy(everywhere)
+  READS: ADMBaseX::gxz(everywhere)
+  READS: ADMBaseX::gyy(everywhere)
+  READS: ADMBaseX::gyz(everywhere)
+  READS: ADMBaseX::gzz(everywhere)
+  READS: ADMBaseX::kxx(everywhere)
+  READS: ADMBaseX::kxy(everywhere)
+  READS: ADMBaseX::kxz(everywhere)
+  READS: ADMBaseX::kyy(everywhere)
+  READS: ADMBaseX::kyz(everywhere)
+  READS: ADMBaseX::kzz(everywhere)
+  WRITES: VolIntegrand2(everywhere) VolIntegrand3(everywhere) VolIntegrand4(everywhere)
+} "Precompute ADM derivative/flux workspaces"
+
+SCHEDULE VI_vacuumX_ComputeIntegrand in VI_vacuumX_VolumeIntegralGroup BEFORE VI_vacuumX_ApplyRegionMasks
+{
+  STORAGE: VolIntegrands,MovingSphRegionIntegrals
   LANG: C
   READS: IntegralCounter(everywhere)
   READS: BoxInBox::position_x(everywhere) BoxInBox::position_y(everywhere) BoxInBox::position_z(everywhere)
@@ -83,10 +106,8 @@ SCHEDULE VI_vacuumX_ComputeIntegrand in VI_vacuumX_VolumeIntegralGroup BEFORE VI
   READS: ADMBaseX::kyy(everywhere)
   READS: ADMBaseX::kyz(everywhere)
   READS: ADMBaseX::kzz(everywhere)
-  WRITES: VolIntegrand1(everywhere)
-  WRITES: VolIntegrand2(everywhere)
-  WRITES: VolIntegrand3(everywhere)
-  WRITES: VolIntegrand4(everywhere)
+  READS: VolIntegrand2(everywhere) VolIntegrand3(everywhere) VolIntegrand4(everywhere)
+  WRITES: VolIntegrand1(interior) VolIntegrand2(interior) VolIntegrand3(interior) VolIntegrand4(interior)
   WRITES: volintegral_inside_sphere__center_x(everywhere)
   WRITES: volintegral_inside_sphere__center_y(everywhere)
   WRITES: volintegral_inside_sphere__center_z(everywhere)
@@ -95,8 +116,24 @@ SCHEDULE VI_vacuumX_ComputeIntegrand in VI_vacuumX_VolumeIntegralGroup BEFORE VI
   WRITES: volintegral_outside_sphere__center_z(everywhere)
 } "Compute Integrand"
 
-SCHEDULE VI_vacuumX_DoSum in VI_vacuumX_VolumeIntegralGroup AFTER VI_vacuumX_ComputeIntegrand
+SCHEDULE VI_vacuumX_ApplyRegionMasks in VI_vacuumX_VolumeIntegralGroup BEFORE VI_vacuumX_DoSum
 {
+  STORAGE: VolIntegrands,MovingSphRegionIntegrals
+  LANG: C
+  READS: IntegralCounter(everywhere)
+  READS: VolIntegrands(interior)
+  READS: volintegral_inside_sphere__center_x(everywhere)
+  READS: volintegral_inside_sphere__center_y(everywhere)
+  READS: volintegral_inside_sphere__center_z(everywhere)
+  READS: volintegral_outside_sphere__center_x(everywhere)
+  READS: volintegral_outside_sphere__center_y(everywhere)
+  READS: volintegral_outside_sphere__center_z(everywhere)
+  WRITES: VolIntegrands(interior)
+} "Apply sphere-based region masks to integrands"
+
+SCHEDULE VI_vacuumX_DoSum in VI_vacuumX_VolumeIntegralGroup AFTER VI_vacuumX_ApplyRegionMasks
+{
+  STORAGE: VolIntegrands,VolIntegrals,MovingSphRegionIntegrals
   OPTIONS: GLOBAL
   LANG: C
   READS: IntegralCounter(everywhere)
@@ -107,7 +144,7 @@ SCHEDULE VI_vacuumX_DoSum in VI_vacuumX_VolumeIntegralGroup AFTER VI_vacuumX_Com
   READS: volintegral_outside_sphere__center_y(everywhere)
   READS: volintegral_outside_sphere__center_z(everywhere)
   READS: VolIntegral(everywhere)
-  READS: VolIntegrands(everywhere)
+  READS: VolIntegrands(interior)
   READS: BoxInBox::position_x(everywhere)
   READS: BoxInBox::position_y(everywhere)
   READS: BoxInBox::position_z(everywhere)
@@ -132,6 +169,7 @@ SCHEDULE VI_vacuumX_DecrementIntegralCounter in VI_vacuumX_VolumeIntegralGroup A
 if(enable_file_output) {
   SCHEDULE VI_vacuumX_file_output after VI_vacuumX_VolumeIntegralGroup AT CCTK_ANALYSIS
   {
+    STORAGE: VolIntegrals,MovingSphRegionIntegrals,VolIntegrals_vacuum_time
     LANG: C
     OPTIONS: GLOBAL
     READS: volintegral_inside_sphere__center_x(everywhere)

--- a/VolumeIntegrals_vacuumX/src/evaluate_integrands_local.cxx
+++ b/VolumeIntegrals_vacuumX/src/evaluate_integrands_local.cxx
@@ -136,11 +136,14 @@ extern "C" void VI_vacuumX_ComputeIntegrandFluxes(CCTK_ARGUMENTS) {
   const CCTK_REAL idx = 1.0 / CCTK_DELTA_SPACE(0);
   const CCTK_REAL idy = 1.0 / CCTK_DELTA_SPACE(1);
   const CCTK_REAL idz = 1.0 / CCTK_DELTA_SPACE(2);
-  vect<int, dim> bnd_min, bnd_max, all_min, all_max, int_min, int_max;
-  grid.boundary_box<1, 1, 1>(grid.nghostzones, bnd_min, bnd_max);
+
+  vect<int, dim> all_min, all_max, int_min, int_max;
+
   grid.box_all<1, 1, 1>(grid.nghostzones, all_min, all_max);
   grid.box_int<1, 1, 1>(grid.nghostzones, int_min, int_max);
+
   using std::max, std::min;
+  
   const vect<int, dim> flux_min = max(all_min, int_min - 1);
   const vect<int, dim> flux_max = min(all_max, int_max + 1);
 

--- a/VolumeIntegrals_vacuumX/src/evaluate_integrands_local.cxx
+++ b/VolumeIntegrals_vacuumX/src/evaluate_integrands_local.cxx
@@ -120,13 +120,93 @@ VI_vacuumX_sample_dynamic_gf(const VI_vacuumX_dynamic_gf &f,
 
 } // namespace
 
+extern "C" void VI_vacuumX_ComputeIntegrandFluxes(CCTK_ARGUMENTS) {
+  DECLARE_CCTK_ARGUMENTSX_VI_vacuumX_ComputeIntegrandFluxes;
+  DECLARE_CCTK_PARAMETERS;
+
+  const int which_integral =
+      NumIntegrals - static_cast<int>(*IntegralCounter) + 1;
+  if (which_integral < 1 || which_integral > NumIntegrals ||
+      which_integral > 100) {
+    CCTK_VERROR("Invalid integral index: which_integral=%d NumIntegrals=%d IntegralCounter=%d",
+                which_integral, NumIntegrals,
+                static_cast<int>(*IntegralCounter));
+  }
+
+  const CCTK_REAL idx = 1.0 / CCTK_DELTA_SPACE(0);
+  const CCTK_REAL idy = 1.0 / CCTK_DELTA_SPACE(1);
+  const CCTK_REAL idz = 1.0 / CCTK_DELTA_SPACE(2);
+  vect<int, dim> bnd_min, bnd_max, all_min, all_max, int_min, int_max;
+  grid.boundary_box<1, 1, 1>(grid.nghostzones, bnd_min, bnd_max);
+  grid.box_all<1, 1, 1>(grid.nghostzones, all_min, all_max);
+  grid.box_int<1, 1, 1>(grid.nghostzones, int_min, int_max);
+  using std::max, std::min;
+  const vect<int, dim> flux_min = max(all_min, int_min - 1);
+  const vect<int, dim> flux_max = min(all_max, int_max + 1);
+
+  if (CCTK_EQUALS(Integration_quantity_keyword[which_integral], "ADM_Mass")) {
+    grid.loop_all_device<1, 1, 1>(
+        grid.nghostzones,
+        [=] CCTK_DEVICE(const PointDesc &p) CCTK_ATTRIBUTE_ALWAYS_INLINE {
+          if (all(p.I >= flux_min && p.I < flux_max)) {
+            VI_vacuumX_ADM_Mass_integrand_eval_derivs(
+                VolIntegrand2, VolIntegrand3, VolIntegrand4, p, idx, idy, idz,
+                alp, gxx, gxy, gxz, gyy, gyz, gzz);
+          } else {
+            VolIntegrand2(p.I) = 0.0;
+            VolIntegrand3(p.I) = 0.0;
+            VolIntegrand4(p.I) = 0.0;
+          }
+        });
+  } else if (CCTK_EQUALS(Integration_quantity_keyword[which_integral],
+                         "ADM_Momentum")) {
+    grid.loop_all_device<1, 1, 1>(
+        grid.nghostzones,
+        [=] CCTK_DEVICE(const PointDesc &p) CCTK_ATTRIBUTE_ALWAYS_INLINE {
+          if (all(p.I >= flux_min && p.I < flux_max)) {
+            VI_vacuumX_ADM_Momentum_integrand_eval_derivs(
+                VolIntegrand2, VolIntegrand3, VolIntegrand4, p, idx, idy, idz,
+                alp, gxx, gxy, gxz, gyy, gyz, gzz, kxx, kxy, kxz, kyy, kyz,
+                kzz);
+          } else {
+            VolIntegrand2(p.I) = 0.0;
+            VolIntegrand3(p.I) = 0.0;
+            VolIntegrand4(p.I) = 0.0;
+          }
+        });
+  } else if (CCTK_EQUALS(Integration_quantity_keyword[which_integral],
+                         "ADM_Angular_Momentum")) {
+    grid.loop_all_device<1, 1, 1>(
+        grid.nghostzones,
+        [=] CCTK_DEVICE(const PointDesc &p) CCTK_ATTRIBUTE_ALWAYS_INLINE {
+          if (all(p.I >= flux_min && p.I < flux_max)) {
+            VI_vacuumX_ADM_Angular_Momentum_integrand_eval_derivs(
+                VolIntegrand2, VolIntegrand3, VolIntegrand4, p, idx, idy, idz,
+                alp, gxx, gxy, gxz, gyy, gyz, gzz, kxx, kxy, kxz, kyy, kyz,
+                kzz);
+          } else {
+            VolIntegrand2(p.I) = 0.0;
+            VolIntegrand3(p.I) = 0.0;
+            VolIntegrand4(p.I) = 0.0;
+          }
+        });
+  } else {
+    grid.loop_all_device<1, 1, 1>(
+        grid.nghostzones,
+        [=] CCTK_DEVICE(const PointDesc &p) CCTK_ATTRIBUTE_ALWAYS_INLINE {
+          VolIntegrand2(p.I) = 0.0;
+          VolIntegrand3(p.I) = 0.0;
+          VolIntegrand4(p.I) = 0.0;
+        });
+  }
+}
+
 extern "C" void VI_vacuumX_ComputeIntegrand(CCTK_ARGUMENTS) {
   DECLARE_CCTK_ARGUMENTSX_VI_vacuumX_ComputeIntegrand;
   DECLARE_CCTK_PARAMETERS;
 
   const int which_integral =
       NumIntegrals - static_cast<int>(*IntegralCounter) + 1;
-
   if (which_integral < 1 || which_integral > NumIntegrals ||
       which_integral > 100) {
     CCTK_VERROR("Invalid integral index: which_integral=%d NumIntegrals=%d IntegralCounter=%d",
@@ -154,7 +234,7 @@ extern "C" void VI_vacuumX_ComputeIntegrand(CCTK_ARGUMENTS) {
     const auto MU2_gf =
         VI_vacuumX_get_dynamic_gf(cctkGH, timelevel, MU2_vi, Momentum2VarString);
 
-    grid.loop_all_device<1, 1, 1>(
+    grid.loop_int_device<1, 1, 1>(
         grid.nghostzones,
         [=] CCTK_DEVICE(const PointDesc &p) CCTK_ATTRIBUTE_ALWAYS_INLINE {
           const CCTK_REAL H = VI_vacuumX_sample_dynamic_gf(H_gf, p);
@@ -187,7 +267,7 @@ extern "C" void VI_vacuumX_ComputeIntegrand(CCTK_ARGUMENTS) {
       const auto MU2_gf = VI_vacuumX_get_dynamic_gf(cctkGH, timelevel, MU2_vi,
                                                     Momentum2VarString);
 
-      grid.loop_all_device<1, 1, 1>(
+      grid.loop_int_device<1, 1, 1>(
           grid.nghostzones,
           [=] CCTK_DEVICE(const PointDesc &p) CCTK_ATTRIBUTE_ALWAYS_INLINE {
             const CCTK_REAL H = VI_vacuumX_sample_dynamic_gf(H_gf, p);
@@ -203,7 +283,7 @@ extern "C" void VI_vacuumX_ComputeIntegrand(CCTK_ARGUMENTS) {
       const auto M2_gf = VI_vacuumX_get_dynamic_gf(cctkGH, timelevel, M2_vi,
                                                    MomentumSquaredVarString);
 
-      grid.loop_all_device<1, 1, 1>(
+      grid.loop_int_device<1, 1, 1>(
           grid.nghostzones,
           [=] CCTK_DEVICE(const PointDesc &p) CCTK_ATTRIBUTE_ALWAYS_INLINE {
             const CCTK_REAL H = VI_vacuumX_sample_dynamic_gf(H_gf, p);
@@ -215,7 +295,7 @@ extern "C" void VI_vacuumX_ComputeIntegrand(CCTK_ARGUMENTS) {
   } else if (CCTK_EQUALS(Integration_quantity_keyword[which_integral],
                          "centeroflapse")) {
 
-    grid.loop_all_device<1, 1, 1>(
+    grid.loop_int_device<1, 1, 1>(
         grid.nghostzones,
         [=] CCTK_DEVICE(const PointDesc &p) CCTK_ATTRIBUTE_ALWAYS_INLINE {
           VI_vacuumX_CoL_integrand(VolIntegrand1, VolIntegrand2, VolIntegrand3,
@@ -229,10 +309,11 @@ extern "C" void VI_vacuumX_ComputeIntegrand(CCTK_ARGUMENTS) {
 
   } else if (CCTK_EQUALS(Integration_quantity_keyword[which_integral], "one")) {
 
-    grid.loop_all_device<1, 1, 1>(
+    grid.loop_int_device<1, 1, 1>(
         grid.nghostzones,
-        [=] CCTK_DEVICE(const PointDesc &p)
-            CCTK_ATTRIBUTE_ALWAYS_INLINE { VolIntegrand1(p.I) = 1.0; });
+        [=] CCTK_DEVICE(const PointDesc &p) CCTK_ATTRIBUTE_ALWAYS_INLINE {
+          VolIntegrand1(p.I) = 1.0;
+        });
 
   } else if (CCTK_EQUALS(Integration_quantity_keyword[which_integral],
                          "ADM_Mass")) {
@@ -240,35 +321,10 @@ extern "C" void VI_vacuumX_ComputeIntegrand(CCTK_ARGUMENTS) {
     const CCTK_REAL idx = 1.0 / CCTK_DELTA_SPACE(0);
     const CCTK_REAL idy = 1.0 / CCTK_DELTA_SPACE(1);
     const CCTK_REAL idz = 1.0 / CCTK_DELTA_SPACE(2);
-    vect<int, dim> imin, imax;
-    grid.box_int<1, 1, 1>(grid.nghostzones, imin, imax);
-
-    grid.loop_all_device<1, 1, 1>(
-        grid.nghostzones,
-        [=] CCTK_DEVICE(const PointDesc &p) CCTK_ATTRIBUTE_ALWAYS_INLINE {
-          VolIntegrand1(p.I) = 0.0;
-          VolIntegrand2(p.I) = 0.0;
-          VolIntegrand3(p.I) = 0.0;
-          VolIntegrand4(p.I) = 0.0;
-        });
 
     grid.loop_int_device<1, 1, 1>(
         grid.nghostzones,
         [=] CCTK_DEVICE(const PointDesc &p) CCTK_ATTRIBUTE_ALWAYS_INLINE {
-          for (int d = 0; d < dim; ++d)
-            if (p.I[d] < imin[d] + 1 || p.I[d] >= imax[d] - 1)
-              return;
-          VI_vacuumX_ADM_Mass_integrand_eval_derivs(
-              VolIntegrand2, VolIntegrand3, VolIntegrand4, p, idx, idy, idz,
-              alp, gxx, gxy, gxz, gyy, gyz, gzz);
-        });
-
-    grid.loop_int_device<1, 1, 1>(
-        grid.nghostzones,
-        [=] CCTK_DEVICE(const PointDesc &p) CCTK_ATTRIBUTE_ALWAYS_INLINE {
-          for (int d = 0; d < dim; ++d)
-            if (p.I[d] < imin[d] + 2 || p.I[d] >= imax[d] - 2)
-              return;
           VI_vacuumX_ADM_Mass_integrand(VolIntegrand1, p, idx, idy, idz,
                                         VolIntegrand2, VolIntegrand3,
                                         VolIntegrand4);
@@ -281,17 +337,8 @@ extern "C" void VI_vacuumX_ComputeIntegrand(CCTK_ARGUMENTS) {
     const CCTK_REAL idy = 1.0 / CCTK_DELTA_SPACE(1);
     const CCTK_REAL idz = 1.0 / CCTK_DELTA_SPACE(2);
 
-    grid.loop_allmn_device<1, 1, 1>(
-        grid.nghostzones, 1,
-        [=] CCTK_DEVICE(const PointDesc &p) CCTK_ATTRIBUTE_ALWAYS_INLINE {
-          VI_vacuumX_ADM_Momentum_integrand_eval_derivs(
-              VolIntegrand2, VolIntegrand3, VolIntegrand4, p, idx, idy, idz,
-              alp, gxx, gxy, gxz, gyy, gyz, gzz, kxx, kxy, kxz, kyy, kyz,
-              kzz);
-        });
-
-    grid.loop_allmn_device<1, 1, 1>(
-        grid.nghostzones, 2,
+    grid.loop_int_device<1, 1, 1>(
+        grid.nghostzones,
         [=] CCTK_DEVICE(const PointDesc &p) CCTK_ATTRIBUTE_ALWAYS_INLINE {
           VI_vacuumX_ADM_Momentum_integrand(VolIntegrand1, p, idx, idy, idz,
                                             VolIntegrand2, VolIntegrand3,
@@ -305,17 +352,8 @@ extern "C" void VI_vacuumX_ComputeIntegrand(CCTK_ARGUMENTS) {
     const CCTK_REAL idy = 1.0 / CCTK_DELTA_SPACE(1);
     const CCTK_REAL idz = 1.0 / CCTK_DELTA_SPACE(2);
 
-    grid.loop_allmn_device<1, 1, 1>(
-        grid.nghostzones, 1,
-        [=] CCTK_DEVICE(const PointDesc &p) CCTK_ATTRIBUTE_ALWAYS_INLINE {
-          VI_vacuumX_ADM_Angular_Momentum_integrand_eval_derivs(
-              VolIntegrand2, VolIntegrand3, VolIntegrand4, p, idx, idy, idz,
-              alp, gxx, gxy, gxz, gyy, gyz, gzz, kxx, kxy, kxz, kyy, kyz,
-              kzz);
-        });
-
-    grid.loop_allmn_device<1, 1, 1>(
-        grid.nghostzones, 2,
+    grid.loop_int_device<1, 1, 1>(
+        grid.nghostzones,
         [=] CCTK_DEVICE(const PointDesc &p) CCTK_ATTRIBUTE_ALWAYS_INLINE {
           VI_vacuumX_ADM_Angular_Momentum_integrand(
               VolIntegrand1, p, idx, idy, idz, VolIntegrand2, VolIntegrand3,
@@ -330,13 +368,10 @@ extern "C" void VI_vacuumX_ComputeIntegrand(CCTK_ARGUMENTS) {
            "understand Integration_quantity_keyword[%d] = %s\n",
            which_integral, Integration_quantity_keyword[which_integral]);
     // Unknown keyword: clear integrands so stale values cannot leak into sums.
-    grid.loop_all_device<1, 1, 1>(
+    grid.loop_int_device<1, 1, 1>(
         grid.nghostzones,
         [=] CCTK_DEVICE(const PointDesc &p) CCTK_ATTRIBUTE_ALWAYS_INLINE {
           VolIntegrand1(p.I) = 0.0;
-          VolIntegrand2(p.I) = 0.0;
-          VolIntegrand3(p.I) = 0.0;
-          VolIntegrand4(p.I) = 0.0;
         });
   }
 
@@ -376,59 +411,80 @@ extern "C" void VI_vacuumX_ComputeIntegrand(CCTK_ARGUMENTS) {
         position_z[which_centre];
   }
 
+}
+
+extern "C" void VI_vacuumX_ApplyRegionMasks(CCTK_ARGUMENTS) {
+  DECLARE_CCTK_ARGUMENTSX_VI_vacuumX_ApplyRegionMasks;
+  DECLARE_CCTK_PARAMETERS;
+
+  const int which_integral =
+      NumIntegrals - static_cast<int>(*IntegralCounter) + 1;
+  if (which_integral < 1 || which_integral > NumIntegrals ||
+      which_integral > 100) {
+    CCTK_VERROR("Invalid integral index: which_integral=%d NumIntegrals=%d IntegralCounter=%d",
+                which_integral, NumIntegrals,
+                static_cast<int>(*IntegralCounter));
+  }
+
   /* ZERO OUT INTEGRATION REGIONS */
 
   /* Set integrands to zero outside a sphere centered at x,y,z.
      I.e., this results in the integral being restricted INSIDE sphere */
-  if (volintegral_inside_sphere__radius[which_integral] > 0.0) {
-    const double radius = volintegral_inside_sphere__radius[which_integral];
-    double xprime = volintegral_sphere__center_x_initial[which_integral];
-    double yprime = volintegral_sphere__center_y_initial[which_integral];
-    double zprime = volintegral_sphere__center_z_initial[which_integral];
+  const bool use_inside_sphere =
+      volintegral_inside_sphere__radius[which_integral] > 0.0;
+  const bool use_outside_sphere =
+      volintegral_outside_sphere__radius[which_integral] > 0.0;
 
-    if (cctk_iteration > 0 &&
-        (amr_centre__tracks__volintegral_inside_sphere[which_integral] != -1 ||
-         volintegral_sphere__tracks__amr_centre[which_integral] != -1)) {
-      xprime = volintegral_inside_sphere__center_x[which_integral];
-      yprime = volintegral_inside_sphere__center_y[which_integral];
-      zprime = volintegral_inside_sphere__center_z[which_integral];
-    }
+  if (!use_inside_sphere && !use_outside_sphere)
+    return;
 
-    grid.loop_all_device<1, 1, 1>(
-        grid.nghostzones,
-        [=] CCTK_DEVICE(const PointDesc &p) CCTK_ATTRIBUTE_ALWAYS_INLINE {
-          const double dx = p.x - xprime;
-          const double dy = p.y - yprime;
-          const double dz = p.z - zprime;
-          if (sqrt(dx * dx + dy * dy + dz * dz) > radius) {
-            VolIntegrand1(p.I) = 0.0;
-            VolIntegrand2(p.I) = 0.0;
-            VolIntegrand3(p.I) = 0.0;
-            VolIntegrand4(p.I) = 0.0;
-          }
-        });
+  const double inside_radius = volintegral_inside_sphere__radius[which_integral];
+  double inside_xprime = volintegral_sphere__center_x_initial[which_integral];
+  double inside_yprime = volintegral_sphere__center_y_initial[which_integral];
+  double inside_zprime = volintegral_sphere__center_z_initial[which_integral];
+
+  if (use_inside_sphere && cctk_iteration > 0 &&
+      (amr_centre__tracks__volintegral_inside_sphere[which_integral] != -1 ||
+       volintegral_sphere__tracks__amr_centre[which_integral] != -1)) {
+    inside_xprime = volintegral_inside_sphere__center_x[which_integral];
+    inside_yprime = volintegral_inside_sphere__center_y[which_integral];
+    inside_zprime = volintegral_inside_sphere__center_z[which_integral];
   }
 
-  /* Set integrands to zero inside a sphere centered at x,y,z.
-     I.e., this results in the integral being restricted OUTSIDE sphere. */
-  if (volintegral_outside_sphere__radius[which_integral] > 0.0) {
-    const double radius = volintegral_outside_sphere__radius[which_integral];
-    const double xprime = volintegral_outside_sphere__center_x[which_integral];
-    const double yprime = volintegral_outside_sphere__center_y[which_integral];
-    const double zprime = volintegral_outside_sphere__center_z[which_integral];
+  const double outside_radius =
+      volintegral_outside_sphere__radius[which_integral];
+  const double outside_xprime = volintegral_outside_sphere__center_x[which_integral];
+  const double outside_yprime = volintegral_outside_sphere__center_y[which_integral];
+  const double outside_zprime = volintegral_outside_sphere__center_z[which_integral];
 
-    grid.loop_all_device<1, 1, 1>(
-        grid.nghostzones,
-        [=] CCTK_DEVICE(const PointDesc &p) CCTK_ATTRIBUTE_ALWAYS_INLINE {
-          const double dx = p.x - xprime;
-          const double dy = p.y - yprime;
-          const double dz = p.z - zprime;
-          if (sqrt(dx * dx + dy * dy + dz * dz) <= radius) {
-            VolIntegrand1(p.I) = 0.0;
-            VolIntegrand2(p.I) = 0.0;
-            VolIntegrand3(p.I) = 0.0;
-            VolIntegrand4(p.I) = 0.0;
-          }
-        });
-  }
+  grid.loop_int_device<1, 1, 1>(
+      grid.nghostzones,
+      [=] CCTK_DEVICE(const PointDesc &p) CCTK_ATTRIBUTE_ALWAYS_INLINE {
+        bool zero_integrand = false;
+
+        if (use_inside_sphere) {
+          const double dx = p.x - inside_xprime;
+          const double dy = p.y - inside_yprime;
+          const double dz = p.z - inside_zprime;
+          zero_integrand =
+              zero_integrand ||
+              (sqrt(dx * dx + dy * dy + dz * dz) > inside_radius);
+        }
+
+        if (use_outside_sphere) {
+          const double dx = p.x - outside_xprime;
+          const double dy = p.y - outside_yprime;
+          const double dz = p.z - outside_zprime;
+          zero_integrand =
+              zero_integrand ||
+              (sqrt(dx * dx + dy * dy + dz * dz) <= outside_radius);
+        }
+
+        if (zero_integrand) {
+          VolIntegrand1(p.I) = 0.0;
+          VolIntegrand2(p.I) = 0.0;
+          VolIntegrand3(p.I) = 0.0;
+          VolIntegrand4(p.I) = 0.0;
+        }
+      });
 }

--- a/VolumeIntegrals_vacuumX/src/integrands.hxx
+++ b/VolumeIntegrals_vacuumX/src/integrands.hxx
@@ -29,9 +29,15 @@ VI_vacuumX_avg_v2c_at(const GF3D2<const T> &gf, const PointDesc &p,
 CCTK_DEVICE CCTK_HOST CCTK_ATTRIBUTE_ALWAYS_INLINE inline void
 VI_vacuumX_L2_integrand(const GF3D2<double> VolIntegrand1,
                         const PointDesc &p,
-                        const GF3D2<const CCTK_REAL> f) {
+                        const GF3D2<const CCTK_REAL> f,
+                        const GF3D2<double> VolIntegrand2,
+                        const GF3D2<double> VolIntegrand3,
+                        const GF3D2<double> VolIntegrand4) {
   const CCTK_REAL fL = f(p.I);
   VolIntegrand1(p.I) = fL * fL;
+  VolIntegrand2(p.I) = 0.0;
+  VolIntegrand3(p.I) = 0.0;
+  VolIntegrand4(p.I) = 0.0;
 }
 
 /* Center of Lapse: */


### PR DESCRIPTION
VolumeIntegrals_*X: make integrand evaluation poison/tile-safe by scheduling region masking separately, ensuring GRMHDX ComputeIntegrand defines all 4 VolIntegrands on the interior, and splitting vacuumX so flux/derivative work for VolIntegrands2/3/4 is computed first and the final VolIntegrand1 is assembled afterward. All VolIntegrands are now only computed on the interior, with unused VolIntegrands set to zero for poison safety.