### PR TITLE
Fix VolumeIntegrals_X for AsterX dev

### DIFF
--- a/VolumeIntegrals_GRMHDX/schedule.ccl
+++ b/VolumeIntegrals_GRMHDX/schedule.ccl
@@ -75,15 +75,9 @@ SCHEDULE VI_GRMHDX_ComputeIntegrand in VI_GRMHDX_VolumeIntegralGroup BEFORE VI_G
   READS: ADMBaseX::gyy(everywhere)
   READS: ADMBaseX::gyz(everywhere)
   READS: ADMBaseX::gzz(everywhere)
-  READS: AsterX::w_lorentz(everywhere)
-  READS: AsterX::b2small(everywhere)
+  READS: AsterX::w_lorentz(interior)
+  READS: AsterX::b2small(interior)
   WRITES: VolIntegrands(interior)
-  WRITES: volintegral_inside_sphere__center_x(everywhere) 
-  WRITES: volintegral_inside_sphere__center_y(everywhere) 
-  WRITES: volintegral_inside_sphere__center_z(everywhere)
-  WRITES: volintegral_outside_sphere__center_x(everywhere) 
-  WRITES: volintegral_outside_sphere__center_y(everywhere) 
-  WRITES: volintegral_outside_sphere__center_z(everywhere)
 } "Compute Integrand"
 
 SCHEDULE VI_GRMHDX_ApplyRegionMasks in VI_GRMHDX_VolumeIntegralGroup BEFORE VI_GRMHDX_DoSum
@@ -119,10 +113,11 @@ SCHEDULE VI_GRMHDX_DoSum in VI_GRMHDX_VolumeIntegralGroup AFTER VI_GRMHDX_ApplyR
   READS: volintegral_outside_sphere__center_y(everywhere)
   READS: volintegral_outside_sphere__center_z(everywhere)
   READS: VolIntegral(everywhere)
-  READS: VolIntegrands(interior)
+  READS: GlobalCoM(everywhere)
   READS: BoxInBox::position_x(everywhere)
   READS: BoxInBox::position_y(everywhere)
   READS: BoxInBox::position_z(everywhere)
+  READS: BoxInBox::active(everywhere)
   WRITES: VolIntegral(everywhere) GlobalCoM(everywhere)
   WRITES: AsterSeeds::CoM_NS1(everywhere) AsterSeeds::CoM_NS2(everywhere)
   WRITES: BoxInBox::position_x(everywhere)
@@ -138,6 +133,7 @@ SCHEDULE VI_GRMHDX_DecrementIntegralCounter in VI_GRMHDX_VolumeIntegralGroup AFT
 {
   LANG: C
   OPTIONS: GLOBAL
+  READS: IntegralCounter(everywhere)
   WRITES: IntegralCounter(everywhere)
 } "Decrement IntegralCounter variable"
 ##################

--- a/VolumeIntegrals_vacuumX/schedule.ccl
+++ b/VolumeIntegrals_vacuumX/schedule.ccl
@@ -104,18 +104,13 @@ SCHEDULE VI_vacuumX_ComputeIntegrand in VI_vacuumX_VolumeIntegralGroup BEFORE VI
   READS: ADMBaseX::kzz(everywhere)
   READS: VolIntegrand2(everywhere) VolIntegrand3(everywhere) VolIntegrand4(everywhere)
   WRITES: VolIntegrand1(interior) VolIntegrand2(interior) VolIntegrand3(interior) VolIntegrand4(interior)
-  WRITES: volintegral_inside_sphere__center_x(everywhere)
-  WRITES: volintegral_inside_sphere__center_y(everywhere)
-  WRITES: volintegral_inside_sphere__center_z(everywhere)
-  WRITES: volintegral_outside_sphere__center_x(everywhere)
-  WRITES: volintegral_outside_sphere__center_y(everywhere)
-  WRITES: volintegral_outside_sphere__center_z(everywhere)
 } "Compute Integrand"
 
 SCHEDULE VI_vacuumX_ApplyRegionMasks in VI_vacuumX_VolumeIntegralGroup BEFORE VI_vacuumX_DoSum
 {
   LANG: C
   READS: IntegralCounter(everywhere)
+  READS: BoxInBox::position_x(everywhere) BoxInBox::position_y(everywhere) BoxInBox::position_z(everywhere)
   READS: VolIntegrands(interior)
   READS: volintegral_inside_sphere__center_x(everywhere)
   READS: volintegral_inside_sphere__center_y(everywhere)
@@ -124,6 +119,12 @@ SCHEDULE VI_vacuumX_ApplyRegionMasks in VI_vacuumX_VolumeIntegralGroup BEFORE VI
   READS: volintegral_outside_sphere__center_y(everywhere)
   READS: volintegral_outside_sphere__center_z(everywhere)
   WRITES: VolIntegrands(interior)
+  WRITES: volintegral_inside_sphere__center_x(everywhere)
+  WRITES: volintegral_inside_sphere__center_y(everywhere)
+  WRITES: volintegral_inside_sphere__center_z(everywhere)
+  WRITES: volintegral_outside_sphere__center_x(everywhere)
+  WRITES: volintegral_outside_sphere__center_y(everywhere)
+  WRITES: volintegral_outside_sphere__center_z(everywhere)
 } "Apply sphere-based region masks to integrands"
 
 SCHEDULE VI_vacuumX_DoSum in VI_vacuumX_VolumeIntegralGroup AFTER VI_vacuumX_ApplyRegionMasks
@@ -138,7 +139,7 @@ SCHEDULE VI_vacuumX_DoSum in VI_vacuumX_VolumeIntegralGroup AFTER VI_vacuumX_App
   READS: volintegral_outside_sphere__center_y(everywhere)
   READS: volintegral_outside_sphere__center_z(everywhere)
   READS: VolIntegral(everywhere)
-  READS: VolIntegrands(interior)
+  READS: BoxInBox::active(everywhere)
   READS: BoxInBox::position_x(everywhere)
   READS: BoxInBox::position_y(everywhere)
   READS: BoxInBox::position_z(everywhere)
@@ -156,6 +157,7 @@ SCHEDULE VI_vacuumX_DecrementIntegralCounter in VI_vacuumX_VolumeIntegralGroup A
 {
   LANG: C
   OPTIONS: GLOBAL
+  READS: IntegralCounter(everywhere)
   WRITES: IntegralCounter(everywhere)
 } "Decrement IntegralCounter variable"
 ##################

--- a/VolumeIntegrals_vacuumX/src/evaluate_integrands_local.cxx
+++ b/VolumeIntegrals_vacuumX/src/evaluate_integrands_local.cxx
@@ -378,6 +378,21 @@ extern "C" void VI_vacuumX_ComputeIntegrand(CCTK_ARGUMENTS) {
         });
   }
 
+}
+
+extern "C" void VI_vacuumX_ApplyRegionMasks(CCTK_ARGUMENTS) {
+  DECLARE_CCTK_ARGUMENTSX_VI_vacuumX_ApplyRegionMasks;
+  DECLARE_CCTK_PARAMETERS;
+
+  const int which_integral =
+      NumIntegrals - static_cast<int>(*IntegralCounter) + 1;
+  if (which_integral < 1 || which_integral > NumIntegrals ||
+      which_integral > 100) {
+    CCTK_VERROR("Invalid integral index: which_integral=%d NumIntegrals=%d IntegralCounter=%d",
+                which_integral, NumIntegrals,
+                static_cast<int>(*IntegralCounter));
+  }
+
   if (cctk_iteration == 0) {
     volintegral_inside_sphere__center_x[which_integral] =
         volintegral_sphere__center_x_initial[which_integral];
@@ -402,9 +417,12 @@ extern "C" void VI_vacuumX_ComputeIntegrand(CCTK_ARGUMENTS) {
                   which_centre, which_integral);
     }
 
-    volintegral_inside_sphere__center_x[which_integral] = position_x[which_centre];
-    volintegral_inside_sphere__center_y[which_integral] = position_y[which_centre];
-    volintegral_inside_sphere__center_z[which_integral] = position_z[which_centre];
+    volintegral_inside_sphere__center_x[which_integral] =
+        position_x[which_centre];
+    volintegral_inside_sphere__center_y[which_integral] =
+        position_y[which_centre];
+    volintegral_inside_sphere__center_z[which_integral] =
+        position_z[which_centre];
 
     volintegral_outside_sphere__center_x[which_integral] =
         position_x[which_centre];
@@ -412,21 +430,6 @@ extern "C" void VI_vacuumX_ComputeIntegrand(CCTK_ARGUMENTS) {
         position_y[which_centre];
     volintegral_outside_sphere__center_z[which_integral] =
         position_z[which_centre];
-  }
-
-}
-
-extern "C" void VI_vacuumX_ApplyRegionMasks(CCTK_ARGUMENTS) {
-  DECLARE_CCTK_ARGUMENTSX_VI_vacuumX_ApplyRegionMasks;
-  DECLARE_CCTK_PARAMETERS;
-
-  const int which_integral =
-      NumIntegrals - static_cast<int>(*IntegralCounter) + 1;
-  if (which_integral < 1 || which_integral > NumIntegrals ||
-      which_integral > 100) {
-    CCTK_VERROR("Invalid integral index: which_integral=%d NumIntegrals=%d IntegralCounter=%d",
-                which_integral, NumIntegrals,
-                static_cast<int>(*IntegralCounter));
   }
 
   /* ZERO OUT INTEGRATION REGIONS */


### PR DESCRIPTION
- Drop stale AsterSeeds dependency/orderings.
- Read AsterX::w_lorentz and AsterX::b2small in GRMHDX schedule.
- Fix GRMHDX/vacuumX schedule metadata for CarpetX poisoning.
- Tested: compiles; 4-iteration poisoned BNS smoke passes with VI tracking.